### PR TITLE
append `*default-special-bindings*` possibly set from elsewhere

### DIFF
--- a/src/thread-util.lisp
+++ b/src/thread-util.lisp
@@ -157,7 +157,7 @@
   `(progn ,@body))
 
 (defmacro with-thread ((&key bindings name) &body body)
-  `(let ((*default-special-bindings* ,bindings))
+  `(let ((*default-special-bindings* (append ,bindings *default-special-bindings*)))
      (make-thread (lambda ()
                     (with-abort-restart
                       ,@body))


### PR DESCRIPTION
following this discussion:
https://github.com/cosmos72/stmx/issues/26

this fixes the interop with STMX (as well as other similar ones, relying on thread bindings)
approved by STMX author in this pr, https://github.com/lmj/lparallel/pull/41