### PR TITLE
Wrap code that wasn't already wrapped in markdown code blocks

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -1,4 +1,4 @@
-API
+## API
 
 The lparallel API is divided into five packages:
 

--- a/docs/Benchmarks.md
+++ b/docs/Benchmarks.md
@@ -1,4 +1,4 @@
-Benchmarks
+## Benchmarks
 
 The following benchmarks were conducted on SBCL / Linux / Core-i7 3.4GHz and Clozure / Darwin / Core 2 Duo 1.8GHz. On SBCL the new work-stealing model with lockless queues is enabled (the default on SBCL). Clozure uses the central queue model.
 
@@ -8,6 +8,7 @@ All arrays are of type (simple-array single-float (*)). The rightmost column is 
 
 SBCL / Linux / 4 cores
 
+```
 size     10 | op SIN      | MAP                 3
 size     10 | op SIN      | MAP                 2
 size     10 | op SIN      | MAP                 3
@@ -413,9 +414,11 @@ n    200 | PMATRIX-MUL        33465
 n    200 | PMATRIX-MUL        33445
 n    200 | PMATRIX-MUL        33444
 n    200 | PMATRIX-MUL        33478
+```
 
 Clozure / Darwin / 2 cores
 
+```
 size     10 | op SIN      | MAP                19
 size     10 | op SIN      | MAP                20
 size     10 | op SIN      | MAP                19
@@ -821,3 +824,4 @@ n    200 | PMATRIX-MUL       166732
 n    200 | PMATRIX-MUL       150359
 n    200 | PMATRIX-MUL       155815
 n    200 | PMATRIX-MUL       154714
+```

--- a/docs/CHANGES.md
+++ b/docs/CHANGES.md
@@ -1,3 +1,4 @@
+## Changes
 
 lparallel-2.8.0 released
 Posted on May 8, 2015 by lparallel	
@@ -69,6 +70,7 @@ Posted on November 5, 2012 by lparallel
 
 Below is another example of Concurrent Hello World. The macros receive and run are just 9 lines each, given below the fold.
 
+```lisp
 (defpackage :example (:use :cl :node))
 (in-package :example)
 
@@ -97,6 +99,7 @@ Below is another example of Concurrent Hello World. The macros receive and run a
       (make-node 'hello hello-queue world-queue)
       (make-node 'world world-queue hello-queue)
       (send hello-queue :say-hello n))))
+```
 
 Continue reading →
 Posted in Uncategorized	| 5 Comments
@@ -157,6 +160,7 @@ Posted on June 24, 2012 by lparallel
 
 When an evaluation fails or is interrupted, it may be convenient to automatically kill tasks created during the evaluation. One use for this might be for debugging a set of long-running tasks. Here is a solution using alexandria’s unwind-protect-case.
 
+```lisp
 (defpackage :example (:use :cl :lparallel :alexandria))
 (in-package :example)
 
@@ -180,6 +184,7 @@ CL-USER> (example::foo) ; ... then hit C-c-c
 WARNING: lparallel: Replacing lost or dead worker.
 WARNING: lparallel: Replacing lost or dead worker.
 ; Evaluation aborted on NIL.
+```
 
 As always, worker threads are regenerated after being killed.
 Posted in Uncategorized	| 1 Comment
@@ -195,6 +200,7 @@ Communicating via conditions
 
 Because task handlers are called immediately when a condition is signaled inside a task, condition handling offers a way to communicate between tasks and the thread which created them. Here is a task which transfers data by signaling:
 
+```lisp
 (defpackage :example (:use :cl :lparallel :lparallel.queue))
 (in-package :example)
 
@@ -211,12 +217,14 @@ Because task handlers are called immediately when a condition is signaled inside
   (pop-queue data))
 
 ; => 99
+```
 
 receive-result has been placed outside of task-handler-bind to emphasize that handlers are bundled at the point of submit-task. (It doesn’t matter where receive-result is called.)
 Multiple kernels
 
 It may be advantageous to have a kernel devoted to particular kinds of tasks. For example one could have specialized channels and futures dedicated to IO.
 
+```lisp
 (defvar *io-kernel* (make-kernel 16))
 
 (defun make-io-channel ()
@@ -226,6 +234,7 @@ It may be advantageous to have a kernel devoted to particular kinds of tasks. Fo
 (defmacro io-future (&body body)
   `(let ((*kernel* *io-kernel*))
      (future ,@body)))
+```
 
 Since a channel remembers its associated kernel, submit-task and receive-result do not depend upon the value of *kernel*. In the promise API, only future and speculate need *kernel*.
 Posted in Uncategorized	| Leave a comment
@@ -284,7 +293,9 @@ Posted in Uncategorized	| Leave a comment
 lparallel is now part of Quicklisp
 Posted on November 7, 2011 by lparallel	
 
+```lisp
 (ql:quickload :lparallel)
+```
 
 Posted in Uncategorized	| Leave a comment
 Welcome

--- a/docs/Cognates.md
+++ b/docs/Cognates.md
@@ -1,4 +1,4 @@
-Cognates
+## Cognates
 
 lparallel provides parallel versions of many Common Lisp functions and macros, each prefixed by ‘p’. They are the pmap family, preduce, and the following.
 
@@ -26,6 +26,7 @@ They return the same results as their CL counterparts except in cases where para
 
 plet is best explained in terms of its macroexpansion.
 
+```lisp
 (defpackage :example (:use :cl :lparallel))
 (in-package :example)
 
@@ -34,14 +35,17 @@ plet is best explained in terms of its macroexpansion.
   (list a b))
 
 ; => (7 11)
+```
 
 The plet form expands to
 
+```lisp
 (LET ((#:A725 (FUTURE (+ 3 4)))
       (#:B726 (FUTURE (+ 5 6))))
   (SYMBOL-MACROLET ((A (FORCE #:A725))
                     (B (FORCE #:B726)))
     (LIST A B)))
+```
 
 See Promises for an explanation of future and force. Since a future’s result is cached (a feature all promises share), references to a and b incur little overhead once their corresponding futures have finished computing.
 

--- a/docs/Handling.md
+++ b/docs/Handling.md
@@ -1,7 +1,8 @@
-Handling
+## Handling
 
 Handling conditions in lparallel is done with task-handler-bind. It is just like handler-bind except that it handles conditions signaled from inside parallel tasks.
 
+```lisp
 (defpackage :example (:use :cl :lparallel))
 (in-package :example)
 
@@ -17,15 +18,17 @@ Handling conditions in lparallel is done with task-handler-bind. It is just like
            '(1 2 3)))
 
 ; => ("number nine" "number nine" "number nine")
+```
 
 Though one may be tempted to merge handler-bind and task-handler-bind with some shadowing magic, in general the handlers which need to reach inside tasks will not always match the handlers that are suitable for the current thread. It is also useful to explicitly flag asynchronous handlers that require thread-safe behavior.
 
 In Common Lisp, the debugger is invoked when an error goes unhandled. By default lparallel mirrors this behavior with regard to tasks: when an error is signaled inside a task, and the error is not handled by one of the task handlers established by task-handler-bind, then the debugger is invoked.
 
-However there is an alternate behavior which may be more appropriate depending upon the situation: automatically transferring errors. Setting *debug-tasks-p* to false will transfer task errors to threads which attempt to obtain the failed results. Suppose you have several parallel tasks running and each task signals an error. If *debug-tasks-p* is false then the debugger will be invoked just once (typically in the parent thread) instead of several times (once for each task).
+However there is an alternate behavior which may be more appropriate depending upon the situation: automatically transferring errors. Setting `*debug-tasks-p*` to false will transfer task errors to threads which attempt to obtain the failed results. Suppose you have several parallel tasks running and each task signals an error. If `*debug-tasks-p*` is false then the debugger will be invoked just once (typically in the parent thread) instead of several times (once for each task).
 
-If *debug-tasks-p* is true then you may still elect to transfer the error yourself. Inside each task there is a restart called TRANSFER-ERROR, which you will see in the debugger. (When *debug-tasks-p* is false the restart is simply invoked for you.) The following shows the Clozure + SLIME environment.
+If `*debug-tasks-p*` is true then you may still elect to transfer the error yourself. Inside each task there is a restart called TRANSFER-ERROR, which you will see in the debugger. (When `*debug-tasks-p*` is false the restart is simply invoked for you.) The following shows the Clozure + SLIME environment.
 
+```lisp
 (pmapcar (lambda (x)
            (when (evenp x)
              (restart-case (error 'foo-error)
@@ -42,9 +45,11 @@ Restarts:
  1: [TRANSFER-ERROR] Transfer this error to a dependent thread, if one exists
  2: [ABORT-BREAK] Reset this thread
  3: [ABORT] Kill this thread
+```
 
 The presence of the TRANSFER-ERROR restart indicates that we are inside a task. After inspecting the backtrace to our satisfaction, it’s time to hit TRANSFER-ERROR. In our example the top-level thread is already waiting for the result, so the debugger will appear again after we transfer.
 
+```lisp
 =>
 Error FOO-ERROR
    [Condition of type FOO-ERROR]
@@ -54,16 +59,21 @@ Restarts:
  1: [*ABORT] Return to SLIME's top level.
  2: [ABORT-BREAK] Reset this thread
  3: [ABORT] Kill this thread
+```
 
 The familiar SLIME restarts are there again. We are back in the top-level thread.
 
 The behavior specified by *debug-tasks-p* may be locally overridden with task-handler-bind. To always transfer errors,
 
+```lisp
 (task-handler-bind ((error #'invoke-transfer-error)) ...)
+```
 
 Likewise to always invoke the debugger for unhandled errors,
 
+```lisp
 (task-handler-bind ((error #'invoke-debugger)) ...)
+```
 
 More on threads
 
@@ -72,23 +82,29 @@ Killing tasks
 
 Occasionally there may be a task which has entered a deadlock (which can happen with circular references) or an infinite loop. Don’t panic! Try
 
+```lisp
 (kill-tasks :default)
+```
 
 This is a blunt weapon, however, because passing :default may cause unrelated tasks to be killed.
 
 Each task is given a task category identifier. When a task is submitted, it is assigned the category of *task-category* which has a default value of :default. The argument to kill-tasks is a task category. Any running task whose category is eql to the argument passed will be killed. Pending tasks are not affected.
 
-To avoid killing unrelated tasks, bind *task-category* around submit-task calls.
+To avoid killing unrelated tasks, bind `*task-category*` around submit-task calls.
 
+```lisp
 (let ((channel (make-channel)))
   ;; ...
   (let ((*task-category* 'my-stuff))
     (submit-task channel (lambda () (loop))))  ; oops!
   (receive-result channel))
+```
 
 This is hung at receive-result. We can recover by calling
 
+```lisp
 (kill-tasks 'my-stuff)
+```
 
 which will only kill our looping task, assuming my-stuff is not used as a task category elsewhere in the same package.
 

--- a/docs/Kernel.md
+++ b/docs/Kernel.md
@@ -1,4 +1,4 @@
-Kernel
+## Kernel
 
 In the context of lparallel, a kernel is an abstract entity that schedules and executes tasks. The lparallel kernel API is meant to describe parallelism in a generic manner.
 
@@ -27,7 +27,7 @@ A task is a function designator together with arguments to the function. To exec
 ; => 7
 ```
 
-If you have not created a kernel (if *kernel* is nil) then upon evaluating the above you will receive an error along with a restart offering to make a kernel for you. Evaluation commences once a kernel is created.
+If you have not created a kernel (if `*kernel*` is nil) then upon evaluating the above you will receive an error along with a restart offering to make a kernel for you. Evaluation commences once a kernel is created.
 
 Multiple tasks may be submitted on the same channel, though the results are not necessarily received in the order in which they were submitted. receive-result receives one result per call.
 
@@ -85,7 +85,7 @@ Binding dynamic variables for use inside tasks may be done on either a per-task 
                            (bar)))))
 ```
 
-This saves the current value of *foo* and, inside the task, binds *foo* to that value for the duration of (bar). You may wish to write a submit-with-my-bindings function to suit your particular needs.
+This saves the current value of `*foo*` and, inside the task, binds `*foo*` to that value for the duration of (bar). You may wish to write a submit-with-my-bindings function to suit your particular needs.
 
 To establish permanent dynamic bindings inside workers (thread-local variables), use the :bindings argument to make-kernel, which is an alist of (var-name . value-form) pairs. Each value-form is evaluated inside each worker when it is created. (So if you have two workers, each value-form will be evaluated twice.)
 
@@ -112,5 +112,4 @@ For more complex scenarios of establishing worker context, a :context function m
   (submit-task channel (lambda () (list *foo* *bar*)))
   (receive-result channel))
 ; => (99 100)
-
 ```

--- a/docs/Promises.md
+++ b/docs/Promises.md
@@ -1,7 +1,8 @@
-Promises
+## Promises
 
 A promise is a receptacle for a result which is unknown at the time it is created. To fulfill a promise is to give it a result. The value of a promise is obtained by forcing it.
 
+```lisp
 (defpackage :example (:use :cl :lparallel))
 (in-package :example)
 
@@ -12,11 +13,13 @@ A promise is a receptacle for a result which is unknown at the time it is create
   (force p))
 
 ; => 3
+```
 
 A promise may be successfully fulfilled only once, after which force will forever return the same result. If fulfill is successful it returns true, otherwise it returns false indicating the promise is already fulfilled (or in the process of being fulfilled). When force is called on an unfulfilled promise, the call will block until the promise is fulfilled.
 
 A future is a promise which is fulfilled in parallel. When a future is created, a parallel task is made from the code passed.
 
+```lisp
 (let ((f (future
            (sleep 0.2)
            (+ 3 4))))
@@ -26,9 +29,11 @@ A future is a promise which is fulfilled in parallel. When a future is created, 
   (force f))
 
 ; => 7
+```
 
 Here are two futures competing to fulfill a promise:
 
+```lisp
 (let* ((p (promise))
        (f (future
             (sleep 0.05)
@@ -39,6 +44,7 @@ Here are two futures competing to fulfill a promise:
   (list (force p) (force f) (force g)))
 
 ; => (F-WAS-HERE T NIL) or (G-WAS-HERE NIL T)
+```
 
 Whichever result appears is dependent upon your system. Note the return value of fulfill indicating success or failure.
 
@@ -50,6 +56,7 @@ Like futures and speculations, a delay is also a promise associated with some co
 
 Futures, speculations, and delays are thus types of promises, and they only differ in how they are fulfilled. In fact they hardly differ in that regard since all must obey fulfill which, if successful, overrides any “fulfillment plan” that may be in place.
 
+```lisp
 (let ((f (future (+ 1 2)))
       (g (delay  (+ 3 4)))
       (h (delay  (+ 5 6))))
@@ -58,6 +65,7 @@ Futures, speculations, and delays are thus types of promises, and they only diff
   (mapcar 'force (list f g h)))
 
 ; => (3 15 11) or (NEVERMIND 15 11)
+```
 
 f‘s planned computation is canceled if the first fulfill happens to grab the future before a worker thread gets it.
 
@@ -65,15 +73,19 @@ For an object which is not a promise, force behaves like identity, returning the
 
 Lastly there is chain, which links objects together by relaying force and fulfilledp calls.
 
+```lisp
 (force (future (delay 3)))         ; => a delay object
 (force (future (chain (delay 3)))) ; => 3
+```
 
 Suppose we wish to cancel a speculation and also signal an error if the speculation is forced after being canceled. This may be accomplished by giving a chained delay to fulfill.
 
+```lisp
 (let ((f (speculate (+ 3 4))))
   (fulfill f (chain (delay (error "speculation canceled!"))))
   (force f))
 
 ; => 7 or #<SIMPLE-ERROR "speculation canceled!">
+```
 
 If chain were not present then force would return a delay object if fulfill succeeded, on which force would have to be called again in order to obtain the error.

--- a/docs/Queues.md
+++ b/docs/Queues.md
@@ -1,4 +1,4 @@
-Queues
+## Queues
 
 The following symbols are exported by the lparallel.queue package. They are not included in the lparallel package.
 

--- a/docs/defpun.md
+++ b/docs/defpun.md
@@ -1,7 +1,8 @@
-defpun
+## defpun
 
 Using plet is often a natural way to add parallelism to an algorithm. The result of doing so may be disappointing, however. Consider the classic Fibonacci example:
 
+```lisp
 (defpackage :example (:use :cl :lparallel))
 (in-package :example)
 
@@ -18,9 +19,11 @@ Using plet is often a natural way to add parallelism to an algorithm. The result
       (plet ((a (pfib-slow (- n 1)))
              (b (pfib-slow (- n 2))))
         (+ a b))))
+```
 
 Living up to its name, pfib-slow is slow. Since plet spawns parallel tasks each time, and since addition is cheap, the overhead of task creation, scheduling, and execution will dominate.
 
+```lisp
 (time (fib 25))
 => 75025
 Evaluation took:
@@ -38,9 +41,11 @@ Evaluation took:
   342.86% CPU
   93,778,257 processor cycles
   29,136,576 bytes consed
+```
 
 How do we fix this? One way is to create fewer tasks by partitioning the computation into larger chunks.
 
+```lisp
 (time (pmap-reduce 'fib '+ #(21 22 22 23)))
 => 75025
 Evaluation took:
@@ -49,18 +54,22 @@ Evaluation took:
   0.00% CPU
   2,771,120 processor cycles
   96 bytes consed
+```
 
 In general it may not be easy to subdivide a computation and then glue the results together, as we have done here. The purpose of defpun is to handle this for us. defpun has the syntax and semantics of defun.
 
+```lisp
 (defpun pfib (n)
   (if (< n 2)
       n
       (plet ((a (pfib (- n 1)))
              (b (pfib (- n 2))))
         (+ a b))))
+```
 
 The above code defines the pfib function.
 
+```lisp
 (time (pfib 25))
 => 75025
 Evaluation took:
@@ -69,6 +78,7 @@ Evaluation took:
   400.00% CPU
   2,601,638 processor cycles
   16,560 bytes consed
+```
 
 See benchmarks for more accurate measurements. Note that a high optimization level inside the defpun form may be required in order to obtain significant speedup.
 

--- a/docs/pmap.md
+++ b/docs/pmap.md
@@ -1,4 +1,4 @@
-pmap
+## pmap
 
 The pmap family consists of parallelized versions of the Common Lisp mapping functions, each denoted by a ‘p’ prefix. They are:
 
@@ -18,30 +18,36 @@ By default pmaps operate on their input sequence(s) in chunks. That is, subseque
 
 The default number of parallel-mapped parts is the number of worker threads (the number given to make-kernel). All pmaps accept a :parts keyword argument for specifying the number of parts explicitly.
 
+```lisp
 (defpackage :example (:use :cl :lparallel))
 (in-package :example)
 
 (pmap 'vector (lambda (x) (* x x)) :parts 2 '(3 4 5))
 ; => #(9 16 25)
+```
 
 (There is no ambiguity in the arguments because the :parts symbol is not a sequence.) When the number of parts is greater than or equal to the number of elements in the result sequence, the subdividing stage is elided and per-element parallelism is performed directly (an optimization).
 
 In addition to :parts, all pmaps accept a :size option for specifying the number of elements to be mapped.
 
+```lisp
 (pmapcar 'identity :size 2 '(a b c d)) ; => (A B)
 
 (map-into  (vector 1 2 3 4) 'identity '(a b))             ; => #(A B 3 4)
 (pmap-into (vector 1 2 3 4) 'identity '(a b))             ; => #(A B 3 4)
 (pmap-into (vector 1 2 3 4) 'identity :size 2 '(a b c d)) ; => #(A B 3 4)
+```
 
 As you probably know, map-into disregards the fill pointer (if one exists) of the result sequence when determining the result size. pmap-into behaves the same way, but also allows the result size to be determined by the :size argument. Like map-into, pmap-into will adjust the fill pointer of the result sequence after mapping is complete.
 
+```lisp
 (let ((vec (make-array 4 :fill-pointer 4 :initial-contents '(1 2 3 4))))
   ;; same as map-into
   (pmap-into vec 'identity '(a b))) ; => #(A B)
 
 (let ((vec (make-array 4 :fill-pointer 4 :initial-contents '(1 2 3 4))))
   (pmap-into vec 'identity :size 2 '(a b c d))) ; => #(A B)
+```
 
 The :size argument also acts as an optimization for lists. Lists are not an ideal structure for parallel mapping because the subdivision process requires lengths to be known. When :size is given, all length calls are skipped.
 

--- a/docs/preduce.md
+++ b/docs/preduce.md
@@ -1,26 +1,32 @@
-preduce
+## preduce
 
 preduce function sequence &key key from-end start end initial-value parts recurse
 
 preduce (pronounced pee-reduce) is a parallel version of reduce. It chops up the input sequence into N parts and, in parallel, calls reduce on each part. The N partial results are then reduced again, either by reduce (the default) or, if the :recurse argument is non-nil, by preduce. The default value of N is the number of worker threads (the number given to make-kernel) which may be overridden by the :parts option.
 
+```lisp
 (defpackage :example (:use :cl :lparallel))
 (in-package :example)
 
 (preduce '+ #(1 2 3 4 5 6) :parts 2)
+```
 
 is hand-wavingly similar to
 
+```lisp
 (reduce '+ (vector (reduce '+ #(1 2 3))
                    (reduce '+ #(4 5 6))))
+```
 
 This code is misleading, of course: the two inner reduces are done in parallel, and the two inner arrays are displaced versions of the input array (no copying is done).
 
 In order for the outcome of preduce to be independent of the choice of parts, the function passed must be associative with respect to the sequence elements and must produce an identity-like function when the :initial-value argument (if given) is partially applied. The latter condition is a consequence of :initial-value really meaning initial value per part.
 
+```lisp
 (preduce '+ #(1 2 3 4 5 6) :parts 1 :initial-value 1)  ; => 22
 (preduce '+ #(1 2 3 4 5 6) :parts 2 :initial-value 1)  ; => 23
 (preduce '+ #(1 2 3 4 5 6) :parts 3 :initial-value 1)  ; => 24
+```
 
 In similar fashion, the :from-end option means from the end of each part.
 
@@ -30,11 +36,14 @@ The :key argument is thrown out while reducing the partial results. It applies t
 
 preduce-partial is a variant of preduce which returns the unmolested partial results.
 
+```lisp
 (preduce-partial '+ #(1 2 3 4 5 6) :parts 2)  ; => #(6 15)
 (preduce-partial '+ #(1 2 3 4 5 6) :parts 3)  ; => #(3 7 11)
+```
 
 We can use preduce-partial to write premove-if for lists.
 
+```lisp
 (defun premove-if* (test list)
   (reduce 'nreconc
           (preduce-partial (lambda (acc x)
@@ -45,5 +54,6 @@ We can use preduce-partial to write premove-if for lists.
                            :initial-value nil)
           :initial-value nil
           :from-end t))
+```
 
 It works as follows: after the partial results are returned by preduce-partial, each being a list in the reverse order of what we wish, we then walk backwards through the results, reversing and concatenating as we go.


### PR DESCRIPTION
- Also add level 2 headings to the top of every page.
- Variables in the prose that were surrounded by asterisks were escaped with single backticks (because the asterisks were part of the variable name).

This is a continuation of the work done in #12 .