### PR TITLE
Add a test key to make-ptree to test its IDs (eg, equalp for string IDs).

### DIFF
--- a/docs/src/Ptrees.md
+++ b/docs/src/Ptrees.md
@@ -51,7 +51,7 @@ The underlying issue is that futures have no knowledge of the computation tree i
 Ptrees may be built dynamically as follows.
 
 ```lisp
-(let ((tree (make-ptree)))
+(let ((tree (make-ptree :test #'eq)))
   (ptree-fn 'area   '(width height) (lambda (w h) (* w h))       tree)
   (ptree-fn 'width  '(border)       (lambda (b)   (+ 7 (* 2 b))) tree)
   (ptree-fn 'height '(border)       (lambda (b)   (+ 5 (* 2 b))) tree)
@@ -61,7 +61,7 @@ Ptrees may be built dynamically as follows.
 ; => 63
 ```
 
-This code resembles the expansion of the ptree macro example above. Note that a node identifier need not be a symbol; any object suitable for eql comparison will do.
+This code resembles the expansion of the ptree macro example above. Note that a node identifier need not be a symbol; any object suitable for `eq`/`eql`/`equal`/`equalp` (default is `eql`) comparison will do.
 
 clear-ptree restores the tree to its original uncomputed state. clear-ptree-errors restores to the last pre-error state.
 

--- a/src/ptree.lisp
+++ b/src/ptree.lisp
@@ -239,9 +239,12 @@
    "A ptree is a computation represented by a tree together with
    functionality to execute the tree in parallel."))
 
-(defun make-ptree ()
+(defun make-ptree ( &key (test #'eql) )
   "Create a ptree instance."
-  (make-ptree-instance))
+  (let ((p (make-ptree-instance)))
+    (with-ptree-slots (nodes) p
+      (setf nodes (make-hash-table :test test)))
+    p))
 
 (defun/type compute-ptree (root ptree kernel) (node ptree kernel) node
   (declare #.*normal-optimize*)


### PR DESCRIPTION
Now it's possible to create ptrees that test compare their identities with any of `eq/eql/equal/equalp` (that the underlying nodes hash map slot accepts), so we can identify them with strings using `equalp` (or so we can use `eq` with symbols).
Default test is still `eql`, as it was originally.